### PR TITLE
Create runecraftinglclickonly

### DIFF
--- a/plugins/runecraftinglclickonly
+++ b/plugins/runecraftinglclickonly
@@ -1,0 +1,2 @@
+repository=https://github.com/Airacan/runecrafinglclickonly.git
+commit=cb097489002ff731584ecf252f6cabb88b99b27c


### PR DESCRIPTION
Makes it so the most used Runecrafting actions such as Fill/Empty essence pouch and withdrawing and depositing Essence/Runes are optimized to take priority as the Left Click action. 
For example, while in bank default action of the Essence Pouchs are 'Fill', while out of bank default action is 'Empty'.